### PR TITLE
fix: name generation of component object

### DIFF
--- a/test/Data/OpenApi/CommonTestTypes.hs
+++ b/test/Data/OpenApi/CommonTestTypes.hs
@@ -259,6 +259,30 @@ playersSchemaJSON = [aesonQQ|
 |]
 
 -- ========================================================================
+-- Player (with type param)
+-- ========================================================================
+
+newtype PlayerPoly a = PlayerPoly
+  { position' :: PointG a
+  } deriving (Generic)
+instance (ToSchema a) => ToSchema (PlayerPoly a)
+
+playerPolySchemaJSON :: Value
+playerPolySchemaJSON = [aesonQQ|
+{
+  "type": "object",
+  "properties":
+    {
+      "position":
+        {
+          "$ref": "#/components/schemas/Point"
+        }
+    },
+  "required": ["position"]
+}
+|]
+
+-- ========================================================================
 -- Character (sum type with ref and record in alternative)
 -- ========================================================================
 
@@ -504,6 +528,18 @@ pointSchemaJSON = [aesonQQ|
   "required": ["x", "y"]
 }
 |]
+
+-- ========================================================================
+-- Point (record data type with custom fieldLabelModifier)
+-- ========================================================================
+
+data PointG a = PointG
+  { pointGX :: a
+  , pointGY :: a
+  } deriving (Generic)
+
+instance ToSchema a => ToSchema (PointG a) where
+  declareNamedSchema = genericDeclareNamedSchema defaultSchemaOptions
 
 -- ========================================================================
 -- Point (record data type with multiple fields)

--- a/test/Data/OpenApi/SchemaSpec.hs
+++ b/test/Data/OpenApi/SchemaSpec.hs
@@ -95,6 +95,7 @@ spec = do
       context "(Int, Float)" $ checkSchemaName Nothing (Proxy :: Proxy (Int, Float))
       context "Person" $ checkSchemaName (Just "Person") (Proxy :: Proxy Person)
       context "Shade" $ checkSchemaName (Just "Shade") (Proxy :: Proxy Shade)
+      context "Player (polymorphic record)" $ checkSchemaName (Just "PlayerPoly__40_PointG_Int_41_") (Proxy :: Proxy (PlayerPoly (PointG Int)))
   describe "Generic Definitions" $ do
     context "Unit" $ checkDefs (Proxy :: Proxy Unit) []
     context "Paint" $ checkDefs (Proxy :: Proxy Paint) ["Color"]


### PR DESCRIPTION
While checking my generated openapi spec with https://editor.swagger.io/ I had errors like:

Semantic error at components.schemas.BaselineCheck_'HasCase_PhysicalUnit Component names can only contain the characters A-Z a-z 0-9 - . _

Looking at the spec:
https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.3.md#components-object This looked like a valid concern: `name must conform to ^[a-zA-Z0-9\.\-_]+$`

This replaces invalid characters by their code.